### PR TITLE
Add empty index.windows.js to allow import with ReactNativeWindows

### DIFF
--- a/index.windows.js
+++ b/index.windows.js
@@ -1,0 +1,4 @@
+'use strict';
+
+export default class CrosswalkWebView {
+}


### PR DESCRIPTION
The file is just a copy of index.ios.js.